### PR TITLE
Create Flutter CoinGlass dashboard app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# CoinGlass Flutter App
+
+A Flutter implementation of a CoinGlass-style cryptocurrency analytics dashboard. The app shows market metrics, funding rates, and liquidation statistics with graceful fallbacks when the public CoinGlass API is not reachable.
+
+## Features
+
+- Dashboard with cards for the most active perpetual futures pairs.
+- Funding rate overview across multiple exchanges.
+- Liquidation statistics with long/short distribution bars.
+- Pull-to-refresh and retry flows to handle transient network failures.
+- Sample data baked in as a fallback when the API is unavailable or an API key has not been provided.
+
+## Getting Started
+
+1. Install Flutter (3.10 or newer is recommended).
+2. Fetch packages:
+
+   ```bash
+   flutter pub get
+   ```
+
+3. (Optional) Create a `--dart-define` with your CoinGlass API secret to unlock live data:
+
+   ```bash
+   flutter run --dart-define=COINGLASS_SECRET=YOUR_KEY_HERE
+   ```
+
+   Without an API key the dashboard will load the bundled sample data so you can still preview the UI offline.
+
+## Project Structure
+
+```
+lib/
+  main.dart              # App entry point
+  src/
+    app.dart             # MaterialApp configuration and theming
+    theme.dart           # Shared theme helper
+    data/
+      models.dart        # Data model classes
+      coinglass_api.dart # REST client with graceful fallbacks
+      sample_data.dart   # Offline sample payloads
+    presentation/
+      home_screen.dart   # Main dashboard experience
+```
+
+## Notes
+
+- The REST endpoints rely on the public CoinGlass API. If the API changes, adjust the `_map*` helpers in `coinglass_api.dart` accordingly.
+- The repository uses `flutter_lints`. Run `flutter analyze` to check for lint issues once Flutter is installed locally.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,9 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - build/**
+
+linter:
+  rules:
+    use_key_in_widget_constructors: false

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+import 'src/app.dart';
+
+void main() {
+  runApp(const CoinGlassApp());
+}

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import 'presentation/home_screen.dart';
+import 'theme.dart';
+
+class CoinGlassApp extends StatelessWidget {
+  const CoinGlassApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'CoinGlass',
+      theme: buildTheme(Brightness.light),
+      darkTheme: buildTheme(Brightness.dark),
+      themeMode: ThemeMode.system,
+      home: const HomeScreen(),
+    );
+  }
+}

--- a/lib/src/data/coinglass_api.dart
+++ b/lib/src/data/coinglass_api.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'models.dart';
+import 'sample_data.dart';
+
+class CoinGlassRepository {
+  CoinGlassRepository({http.Client? client, this.apiKey})
+      : _client = client ?? http.Client();
+
+  final http.Client _client;
+  final String? apiKey;
+
+  static const _baseUrl = 'https://open-api.coinglass.com/public/v2';
+
+  Map<String, String> get _headers => <String, String>{
+        'accept': 'application/json',
+        if (apiKey != null && apiKey!.isNotEmpty) 'coinglassSecret': apiKey!,
+      };
+
+  Future<List<CoinMetrics>> fetchCoinMetrics() async {
+    final uri = Uri.parse('$_baseUrl/futures/tickers?interval=24h');
+
+    final response = await _safeGet(uri);
+    if (response == null) {
+      return sampleCoinMetrics
+          .map((dynamic item) =>
+              CoinMetrics.fromJson(item as Map<String, dynamic>))
+          .toList();
+    }
+
+    final payload = jsonDecode(response.body) as Map<String, dynamic>;
+    final data = payload['data'];
+    if (data is List) {
+      return data
+          .map((dynamic item) => CoinMetrics.fromJson(
+                _mapCoinMetrics(item as Map<String, dynamic>),
+              ))
+          .toList();
+    }
+
+    return sampleCoinMetrics
+        .map((dynamic item) => CoinMetrics.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<FundingRate>> fetchFundingRates() async {
+    final uri = Uri.parse('$_baseUrl/futures/fundingRate/list');
+    final response = await _safeGet(uri);
+    if (response == null) {
+      return sampleFundingRates
+          .map((dynamic item) =>
+              FundingRate.fromJson(item as Map<String, dynamic>))
+          .toList();
+    }
+
+    final payload = jsonDecode(response.body) as Map<String, dynamic>;
+    final data = payload['data'];
+    if (data is List) {
+      return data
+          .map((dynamic item) => FundingRate.fromJson(
+                _mapFundingRate(item as Map<String, dynamic>),
+              ))
+          .toList();
+    }
+
+    return sampleFundingRates
+        .map((dynamic item) => FundingRate.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<LiquidationStat>> fetchLiquidationStats() async {
+    final uri = Uri.parse('$_baseUrl/futures/liquidation');
+    final response = await _safeGet(uri);
+    if (response == null) {
+      return sampleLiquidationStats
+          .map((dynamic item) =>
+              LiquidationStat.fromJson(item as Map<String, dynamic>))
+          .toList();
+    }
+
+    final payload = jsonDecode(response.body) as Map<String, dynamic>;
+    final data = payload['data'];
+    if (data is List) {
+      return data
+          .map((dynamic item) => LiquidationStat.fromJson(
+                _mapLiquidation(item as Map<String, dynamic>),
+              ))
+          .toList();
+    }
+
+    return sampleLiquidationStats
+        .map((dynamic item) =>
+            LiquidationStat.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<http.Response?> _safeGet(Uri uri) async {
+    try {
+      final response = await _client.get(uri, headers: _headers);
+      if (response.statusCode == 200) {
+        return response;
+      }
+    } catch (_) {
+      return null;
+    }
+    return null;
+  }
+
+  Map<String, dynamic> _mapCoinMetrics(Map<String, dynamic> json) {
+    return <String, dynamic>{
+      'symbol': json['symbol'] ?? json['pair'] ?? 'UNKNOWN',
+      'price': _toDouble(json['price'] ?? json['uPrice']),
+      'change24h': _toDouble(json['chgPct'] ?? json['change']),
+      'openInterest': _toDouble(json['openInterest'] ?? json['oi']),
+      'volume24h': _toDouble(json['volume'] ?? json['vol']),
+      'longShortRatio': _toDouble(json['longShortRatio'] ?? json['lsr'] ?? 1),
+    };
+  }
+
+  Map<String, dynamic> _mapFundingRate(Map<String, dynamic> json) {
+    return <String, dynamic>{
+      'symbol': json['symbol'] ?? json['pair'] ?? 'UNKNOWN',
+      'exchange': json['exchange'] ?? json['market'] ?? 'Unknown',
+      'rate': _toDouble(json['rate'] ?? json['fundingRate']),
+    };
+  }
+
+  Map<String, dynamic> _mapLiquidation(Map<String, dynamic> json) {
+    return <String, dynamic>{
+      'exchange': json['exchange'] ?? json['market'] ?? 'Unknown',
+      'longLiquidations':
+          _toDouble(json['long'] ?? json['longLiquidations']),
+      'shortLiquidations':
+          _toDouble(json['short'] ?? json['shortLiquidations']),
+    };
+  }
+
+  double _toDouble(dynamic value) {
+    if (value is num) {
+      return value.toDouble();
+    }
+    if (value is String) {
+      return double.tryParse(value) ?? 0;
+    }
+    return 0;
+  }
+
+  void dispose() {
+    _client.close();
+  }
+}

--- a/lib/src/data/models.dart
+++ b/lib/src/data/models.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+class CoinMetrics {
+  const CoinMetrics({
+    required this.symbol,
+    required this.price,
+    required this.change24h,
+    required this.openInterest,
+    required this.volume24h,
+    required this.longShortRatio,
+  });
+
+  factory CoinMetrics.fromJson(Map<String, dynamic> json) {
+    return CoinMetrics(
+      symbol: json['symbol'] as String,
+      price: (json['price'] as num).toDouble(),
+      change24h: (json['change24h'] as num).toDouble(),
+      openInterest: (json['openInterest'] as num).toDouble(),
+      volume24h: (json['volume24h'] as num).toDouble(),
+      longShortRatio: (json['longShortRatio'] as num).toDouble(),
+    );
+  }
+
+  factory CoinMetrics.fromRawJson(String source) =>
+      CoinMetrics.fromJson(jsonDecode(source) as Map<String, dynamic>);
+
+  final String symbol;
+  final double price;
+  final double change24h;
+  final double openInterest;
+  final double volume24h;
+  final double longShortRatio;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'symbol': symbol,
+        'price': price,
+        'change24h': change24h,
+        'openInterest': openInterest,
+        'volume24h': volume24h,
+        'longShortRatio': longShortRatio,
+      };
+}
+
+class FundingRate {
+  const FundingRate({
+    required this.symbol,
+    required this.exchange,
+    required this.rate,
+  });
+
+  factory FundingRate.fromJson(Map<String, dynamic> json) {
+    return FundingRate(
+      symbol: json['symbol'] as String,
+      exchange: json['exchange'] as String,
+      rate: (json['rate'] as num).toDouble(),
+    );
+  }
+
+  factory FundingRate.fromRawJson(String source) =>
+      FundingRate.fromJson(jsonDecode(source) as Map<String, dynamic>);
+
+  final String symbol;
+  final String exchange;
+  final double rate;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'symbol': symbol,
+        'exchange': exchange,
+        'rate': rate,
+      };
+}
+
+class LiquidationStat {
+  const LiquidationStat({
+    required this.exchange,
+    required this.longLiquidations,
+    required this.shortLiquidations,
+  });
+
+  factory LiquidationStat.fromJson(Map<String, dynamic> json) {
+    return LiquidationStat(
+      exchange: json['exchange'] as String,
+      longLiquidations: (json['longLiquidations'] as num).toDouble(),
+      shortLiquidations: (json['shortLiquidations'] as num).toDouble(),
+    );
+  }
+
+  factory LiquidationStat.fromRawJson(String source) =>
+      LiquidationStat.fromJson(jsonDecode(source) as Map<String, dynamic>);
+
+  final String exchange;
+  final double longLiquidations;
+  final double shortLiquidations;
+
+  double get total => longLiquidations + shortLiquidations;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'exchange': exchange,
+        'longLiquidations': longLiquidations,
+        'shortLiquidations': shortLiquidations,
+      };
+}

--- a/lib/src/data/sample_data.dart
+++ b/lib/src/data/sample_data.dart
@@ -1,0 +1,70 @@
+const sampleCoinMetrics = [
+  {
+    'symbol': 'BTC',
+    'price': 27204.52,
+    'change24h': 1.24,
+    'openInterest': 1089432450.0,
+    'volume24h': 23894235000.0,
+    'longShortRatio': 0.92,
+  },
+  {
+    'symbol': 'ETH',
+    'price': 1642.11,
+    'change24h': -0.42,
+    'openInterest': 489432320.0,
+    'volume24h': 12389234000.0,
+    'longShortRatio': 1.08,
+  },
+  {
+    'symbol': 'SOL',
+    'price': 19.75,
+    'change24h': 3.52,
+    'openInterest': 11389230.0,
+    'volume24h': 639823400.0,
+    'longShortRatio': 1.14,
+  },
+  {
+    'symbol': 'XRP',
+    'price': 0.52,
+    'change24h': -1.12,
+    'openInterest': 8934230.0,
+    'volume24h': 489234500.0,
+    'longShortRatio': 0.87,
+  },
+];
+
+const sampleFundingRates = [
+  {
+    'symbol': 'BTC',
+    'exchange': 'Binance',
+    'rate': 0.012,
+  },
+  {
+    'symbol': 'ETH',
+    'exchange': 'OKX',
+    'rate': -0.004,
+  },
+  {
+    'symbol': 'SOL',
+    'exchange': 'Bybit',
+    'rate': 0.007,
+  },
+];
+
+const sampleLiquidationStats = [
+  {
+    'exchange': 'Binance',
+    'longLiquidations': 23948320.0,
+    'shortLiquidations': 18349320.0,
+  },
+  {
+    'exchange': 'OKX',
+    'longLiquidations': 12384320.0,
+    'shortLiquidations': 19348320.0,
+  },
+  {
+    'exchange': 'Bybit',
+    'longLiquidations': 9394832.0,
+    'shortLiquidations': 7384932.0,
+  },
+];

--- a/lib/src/presentation/home_screen.dart
+++ b/lib/src/presentation/home_screen.dart
@@ -1,0 +1,501 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../data/coinglass_api.dart';
+import '../data/models.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final CoinGlassRepository _repository = CoinGlassRepository(
+    apiKey: const String.fromEnvironment('COINGLASS_SECRET'),
+  );
+  late Future<_DashboardData> _dashboardFuture;
+
+  final NumberFormat _priceFormat = NumberFormat.simpleCurrency(decimalDigits: 2);
+  final NumberFormat _compactFormat = NumberFormat.compactSimpleCurrency(decimalDigits: 0);
+
+  @override
+  void initState() {
+    super.initState();
+    _dashboardFuture = _loadDashboard();
+  }
+
+  Future<_DashboardData> _loadDashboard() async {
+    final metrics = await _repository.fetchCoinMetrics();
+    final fundingRates = await _repository.fetchFundingRates();
+    final liquidation = await _repository.fetchLiquidationStats();
+    return _DashboardData(
+      metrics: metrics,
+      fundingRates: fundingRates,
+      liquidation: liquidation,
+    );
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _dashboardFuture = _loadDashboard();
+    });
+    await _dashboardFuture;
+  }
+
+  @override
+  void dispose() {
+    _repository.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('CoinGlass Dashboard'),
+        actions: [
+          IconButton(
+            tooltip: 'Refresh',
+            onPressed: () => _refresh(),
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: FutureBuilder<_DashboardData>(
+        future: _dashboardFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return _ErrorState(
+              error: snapshot.error,
+              onRetry: _refresh,
+            );
+          }
+
+          final data = snapshot.data;
+          if (data == null) {
+            return const SizedBox.shrink();
+          }
+
+          final displayedMetrics = data.metrics.take(6).toList();
+
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                const SizedBox(height: 8),
+                const _SectionHeader(
+                  title: '热门合约',
+                  subtitle: '关注主流币种的价格、持仓与多空比',
+                ),
+                SizedBox(
+                  height: 210,
+                  child: ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    itemCount: displayedMetrics.length,
+                    itemBuilder: (context, index) {
+                      final metric = displayedMetrics[index];
+                      return _CoinMetricsCard(
+                        metrics: metric,
+                        priceFormat: _priceFormat,
+                        compactFormat: _compactFormat,
+                      );
+                    },
+                  ),
+                ),
+                const SizedBox(height: 24),
+                const _SectionHeader(
+                  title: '资金费率',
+                  subtitle: '监测不同交易所的多空情绪',
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Column(
+                    children: data.fundingRates
+                        .map(
+                          (rate) => _FundingRateTile(
+                            rate: rate,
+                            percentText: '${rate.rate.toStringAsFixed(3)}%',
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                const _SectionHeader(
+                  title: '爆仓数据',
+                  subtitle: '了解市场杠杆风险的集中区域',
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Column(
+                    children: data.liquidation
+                        .map(
+                          (stat) => _LiquidationTile(
+                            stat: stat,
+                            formatter: _compactFormat,
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
+                const SizedBox(height: 32),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            subtitle,
+            style: theme.textTheme.bodyMedium?.copyWith(color: theme.hintColor),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CoinMetricsCard extends StatelessWidget {
+  const _CoinMetricsCard({
+    required this.metrics,
+    required this.priceFormat,
+    required this.compactFormat,
+  });
+
+  final CoinMetrics metrics;
+  final NumberFormat priceFormat;
+  final NumberFormat compactFormat;
+
+  Color _trendColor(BuildContext context) {
+    if (metrics.change24h > 0) {
+      return Colors.green.shade600;
+    }
+    if (metrics.change24h < 0) {
+      return Colors.red.shade600;
+    }
+    return Theme.of(context).colorScheme.secondary;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = _trendColor(context);
+
+    return SizedBox(
+      width: 260,
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  CircleAvatar(
+                    backgroundColor: theme.colorScheme.primary.withOpacity(0.1),
+                    child: Text(_initials(metrics.symbol)),
+                  ),
+                  const SizedBox(width: 12),
+                  Text(
+                    metrics.symbol,
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const Spacer(),
+                  Chip(
+                    label: Text(
+                      metrics.change24h >= 0
+                          ? '+${metrics.change24h.toStringAsFixed(2)}%'
+                          : '${metrics.change24h.toStringAsFixed(2)}%',
+                    ),
+                    backgroundColor: color.withOpacity(0.1),
+                    labelStyle: theme.textTheme.bodyMedium?.copyWith(
+                      color: color,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Text(
+                priceFormat.format(metrics.price),
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 12),
+              _MetricRow(
+                label: '24h成交量',
+                value: compactFormat.format(metrics.volume24h),
+              ),
+              const SizedBox(height: 12),
+              _MetricRow(
+                label: '持仓量',
+                value: compactFormat.format(metrics.openInterest),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                '多空比 ${metrics.longShortRatio.toStringAsFixed(2)}',
+                style: theme.textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 8),
+              LinearProgressIndicator(
+                value: (metrics.longShortRatio / 2).clamp(0.0, 1.0),
+                color: theme.colorScheme.primary,
+                backgroundColor: theme.colorScheme.primary.withOpacity(0.1),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MetricRow extends StatelessWidget {
+  const _MetricRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.hintColor,
+          ),
+        ),
+        Text(
+          value,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FundingRateTile extends StatelessWidget {
+  const _FundingRateTile({required this.rate, required this.percentText});
+
+  final FundingRate rate;
+  final String percentText;
+
+  Color _trendColor(BuildContext context) {
+    if (rate.rate > 0) {
+      return Colors.green.shade600;
+    }
+    if (rate.rate < 0) {
+      return Colors.red.shade600;
+    }
+    return Theme.of(context).colorScheme.secondary;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = _trendColor(context);
+    return Card(
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: theme.colorScheme.secondaryContainer,
+          child: Text(_initials(rate.symbol)),
+        ),
+        title: Text('${rate.symbol} · ${rate.exchange}'),
+        subtitle: const Text('资金费率'),
+        trailing: Text(
+          percentText,
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: color,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LiquidationTile extends StatelessWidget {
+  const _LiquidationTile({required this.stat, required this.formatter});
+
+  final LiquidationStat stat;
+  final NumberFormat formatter;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final total = stat.total;
+    final longPct = total == 0 ? 0.5 : stat.longLiquidations / total;
+    final shortPct = total == 0 ? 0.5 : stat.shortLiquidations / total;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(
+                  backgroundColor: theme.colorScheme.primary.withOpacity(0.1),
+                  child: Text(_initials(stat.exchange)),
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  stat.exchange,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const Spacer(),
+                Text(
+                  formatter.format(total),
+                  style: theme.textTheme.titleMedium,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('多头: ${formatter.format(stat.longLiquidations)}'),
+                Text('空头: ${formatter.format(stat.shortLiquidations)}'),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  flex: (longPct * 1000).round(),
+                  child: Container(
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: Colors.green.shade400,
+                      borderRadius: const BorderRadius.horizontal(left: Radius.circular(4)),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  flex: (shortPct * 1000).round(),
+                  child: Container(
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: Colors.red.shade400,
+                      borderRadius: const BorderRadius.horizontal(right: Radius.circular(4)),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({this.error, required this.onRetry});
+
+  final Object? error;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.wifi_off,
+              size: 48,
+              color: theme.colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '无法连接到服务器',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              error?.toString() ?? '请检查网络或稍后重试。',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('重试'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DashboardData {
+  const _DashboardData({
+    required this.metrics,
+    required this.fundingRates,
+    required this.liquidation,
+  });
+
+  final List<CoinMetrics> metrics;
+  final List<FundingRate> fundingRates;
+  final List<LiquidationStat> liquidation;
+}
+
+String _initials(String value) {
+  if (value.isEmpty) {
+    return '--';
+  }
+  final sanitized = value.replaceAll(RegExp(r'[^A-Za-z0-9]'), '').toUpperCase();
+  if (sanitized.isEmpty) {
+    return '--';
+  }
+  if (sanitized.length >= 2) {
+    return sanitized.substring(0, 2);
+  }
+  return sanitized.padRight(2, sanitized[0]);
+}

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+ThemeData buildTheme(Brightness brightness) {
+  final base = ThemeData(
+    brightness: brightness,
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: const Color(0xFF1B5E20),
+      brightness: brightness,
+    ),
+    useMaterial3: true,
+  );
+
+  return base.copyWith(
+    textTheme: base.textTheme.apply(
+      fontFamily: 'Roboto',
+    ),
+    cardTheme: base.cardTheme.copyWith(
+      elevation: 2,
+      margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+    ),
+    appBarTheme: base.appBarTheme.copyWith(
+      centerTitle: true,
+      elevation: 0,
+      backgroundColor: Colors.transparent,
+      surfaceTintColor: Colors.transparent,
+    ),
+    chipTheme: base.chipTheme.copyWith(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      labelStyle: base.textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold),
+    ),
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,26 @@
+name: coinglass_app
+description: A Flutter implementation of a CoinGlass-style cryptocurrency analytics app.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: ">=2.19.0 <4.0.0"
+  flutter: ">=3.10.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.5
+  intl: ^0.18.1
+
+  # The following adds the Cupertino Icons font to your application.
+  # Use with the CupertinoIcons class for iOS style icons.
+  cupertino_icons: ^1.0.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.2
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold the Flutter app with shared theming and entry point
- implement data models, sample payloads, and repository to fetch CoinGlass metrics with graceful fallbacks
- build a dashboard UI that surfaces futures metrics, funding rates, and liquidation statistics with refresh and error handling

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce62caaff88328af1f53bcd239503f