### PR TITLE
Implement profile tab and login screen navigation

### DIFF
--- a/lib/src/presentation/home_screen.dart
+++ b/lib/src/presentation/home_screen.dart
@@ -5,7 +5,8 @@ import 'package:intl/intl.dart';
 
 import '../data/coinglass_api.dart';
 import '../data/models.dart';
-import '../router/app_router.dart' show ReminderRoute;
+import '../router/app_router.dart' show LoginRoute, ReminderRoute;
+import 'my_profile_tab.dart';
 import 'widgets/custom_bottom_nav_bar.dart';
 
 const List<String> _categoryLabels = <String>[
@@ -67,6 +68,10 @@ class _HomeScreenState extends State<HomeScreen> {
       ..showSnackBar(
         const SnackBar(content: Text('功能开发中，敬请期待。')),
       );
+  }
+
+  void _openLogin() {
+    context.router.push(const LoginRoute());
   }
 
   void _openReminderCenter() {
@@ -199,7 +204,10 @@ class _HomeScreenState extends State<HomeScreen> {
             const _ComingSoonView(title: '清算地图'),
             const _ComingSoonView(title: '爆仓信息'),
             const _ComingSoonView(title: '多空比'),
-            const _ComingSoonView(title: '资金费率'),
+            MyProfileTab(
+              onLoginTap: _openLogin,
+              onPlaceholderTap: _showComingSoon,
+            ),
           ],
         );
       }),

--- a/lib/src/presentation/login_screen.dart
+++ b/lib/src/presentation/login_screen.dart
@@ -1,0 +1,213 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+
+@RoutePage()
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      backgroundColor: theme.colorScheme.surface,
+      body: SafeArea(
+        child: ListView(
+          physics: const BouncingScrollPhysics(),
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+          children: <Widget>[
+            Align(
+              alignment: Alignment.centerLeft,
+              child: IconButton(
+                icon: const Icon(Icons.close),
+                tooltip: '关闭',
+                onPressed: () => context.router.maybePop(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              '登录',
+              style: theme.textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 32),
+            _LoginInputField(
+              controller: _emailController,
+              label: '邮箱',
+              keyboardType: TextInputType.emailAddress,
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: 16),
+            _LoginInputField(
+              controller: _passwordController,
+              label: '密码',
+              obscureText: true,
+              textInputAction: TextInputAction.done,
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () {},
+                child: const Text('忘记密码?'),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                ),
+                child: const Text('登录'),
+              ),
+            ),
+            const SizedBox(height: 32),
+            Divider(
+              color: theme.colorScheme.outlineVariant.withOpacity(0.6),
+            ),
+            const SizedBox(height: 24),
+            _SocialLoginButton(
+              icon: Icons.g_translate,
+              label: '使用 Google 账号登录',
+              onPressed: () {},
+            ),
+            const SizedBox(height: 12),
+            _SocialLoginButton(
+              icon: Icons.apple,
+              label: '使用 Apple 账号登录',
+              onPressed: () {},
+            ),
+            const SizedBox(height: 32),
+            Center(
+              child: Wrap(
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: 6,
+                children: <Widget>[
+                  Text(
+                    '还没有账号?',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  GestureDetector(
+                    onTap: () {},
+                    child: Text(
+                      '注册',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.primary,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LoginInputField extends StatelessWidget {
+  const _LoginInputField({
+    required this.controller,
+    required this.label,
+    this.obscureText = false,
+    this.keyboardType,
+    this.textInputAction,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+  final TextInputAction? textInputAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return TextField(
+      controller: controller,
+      obscureText: obscureText,
+      keyboardType: keyboardType,
+      textInputAction: textInputAction,
+      decoration: InputDecoration(
+        labelText: label,
+        filled: true,
+        fillColor: theme.colorScheme.surfaceVariant.withOpacity(0.4),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide.none,
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(
+            color: theme.colorScheme.primary,
+            width: 1.5,
+          ),
+        ),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      ),
+    );
+  }
+}
+
+class _SocialLoginButton extends StatelessWidget {
+  const _SocialLoginButton({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return OutlinedButton(
+      onPressed: onPressed,
+      style: OutlinedButton.styleFrom(
+        minimumSize: const Size.fromHeight(52),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(14),
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(icon, size: 22, color: theme.colorScheme.onSurface),
+          const SizedBox(width: 12),
+          Text(
+            label,
+            style: theme.textTheme.labelLarge,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/my_profile_tab.dart
+++ b/lib/src/presentation/my_profile_tab.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+
+class MyProfileTab extends StatelessWidget {
+  const MyProfileTab({
+    super.key,
+    required this.onLoginTap,
+    required this.onPlaceholderTap,
+  });
+
+  final VoidCallback onLoginTap;
+  final VoidCallback onPlaceholderTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final Color backgroundColor = theme.colorScheme.surfaceVariant.withOpacity(
+      theme.brightness == Brightness.dark ? 0.25 : 0.15,
+    );
+
+    return ColoredBox(
+      color: backgroundColor,
+      child: SafeArea(
+        bottom: false,
+        child: ListView(
+          physics: const BouncingScrollPhysics(),
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          children: <Widget>[
+            Text(
+              '我的',
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 24),
+            _ProfileHeader(onTap: onLoginTap),
+            const SizedBox(height: 24),
+            _SettingsCard(
+              items: <_SettingsItemData>[
+                _SettingsItemData(
+                  icon: Icons.notifications_none_outlined,
+                  label: '提醒',
+                  onTap: onPlaceholderTap,
+                ),
+                _SettingsItemData(
+                  icon: Icons.history_toggle_off,
+                  label: '历史提醒',
+                  onTap: onPlaceholderTap,
+                ),
+                _SettingsItemData(
+                  icon: Icons.wb_sunny_outlined,
+                  label: '外观',
+                  onTap: onPlaceholderTap,
+                ),
+                _SettingsItemData(
+                  icon: Icons.language,
+                  label: '语言',
+                  trailingLabel: '简体中文',
+                  onTap: onPlaceholderTap,
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _SettingsCard(
+              items: <_SettingsItemData>[
+                _SettingsItemData(
+                  icon: Icons.settings_outlined,
+                  label: '更多设置',
+                  onTap: onPlaceholderTap,
+                ),
+                _SettingsItemData(
+                  icon: Icons.share_outlined,
+                  label: '分享',
+                  onTap: onPlaceholderTap,
+                ),
+                _SettingsItemData(
+                  icon: Icons.star_border_rounded,
+                  label: '给 CoinGlass 评分',
+                  onTap: onPlaceholderTap,
+                ),
+              ],
+            ),
+            const SizedBox(height: 32),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProfileHeader extends StatelessWidget {
+  const _ProfileHeader({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final Color surface = theme.colorScheme.surface;
+    final Color accent = theme.colorScheme.primary;
+
+    return Material(
+      color: surface,
+      borderRadius: BorderRadius.circular(24),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(24),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Row(
+            children: <Widget>[
+              CircleAvatar(
+                radius: 30,
+                backgroundColor: accent.withOpacity(0.12),
+                child: Icon(
+                  Icons.person_outline,
+                  size: 30,
+                  color: accent,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      '登录/注册',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      '组合记录',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chevron_right,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsCard extends StatelessWidget {
+  const _SettingsCard({required this.items});
+
+  final List<_SettingsItemData> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      elevation: 0,
+      color: theme.colorScheme.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: Column(
+        children: <Widget>[
+          for (int i = 0; i < items.length; i++) ...<Widget>[
+            if (i != 0)
+              Divider(
+                height: 1,
+                thickness: 1,
+                indent: 72,
+                color: theme.dividerColor.withOpacity(0.3),
+              ),
+            _SettingsTile(data: items[i]),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsItemData {
+  const _SettingsItemData({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.trailingLabel,
+  });
+
+  final IconData icon;
+  final String label;
+  final String? trailingLabel;
+  final VoidCallback onTap;
+}
+
+class _SettingsTile extends StatelessWidget {
+  const _SettingsTile({required this.data});
+
+  final _SettingsItemData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final Color accent = theme.colorScheme.primary;
+
+    return ListTile(
+      onTap: data.onTap,
+      leading: Container(
+        width: 44,
+        height: 44,
+        decoration: BoxDecoration(
+          color: accent.withOpacity(0.12),
+          shape: BoxShape.circle,
+        ),
+        alignment: Alignment.center,
+        child: Icon(data.icon, color: accent, size: 22),
+      ),
+      title: Text(
+        data.label,
+        style: theme.textTheme.bodyLarge?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          if (data.trailingLabel != null) ...<Widget>[
+            Text(
+              data.trailingLabel!,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(width: 6),
+          ],
+          Icon(
+            Icons.chevron_right,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/router/app_router.dart
+++ b/lib/src/router/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 
 import '../presentation/home_screen.dart';
+import '../presentation/login_screen.dart';
 import '../presentation/reminder_screen.dart';
 
 part 'app_router.gr.dart';
@@ -11,5 +12,12 @@ class AppRouter extends _$AppRouter {
   List<AutoRoute> get routes => <AutoRoute>[
         AutoRoute(page: HomeRoute.page, path: '/'),
         AutoRoute(page: ReminderRoute.page, path: '/reminder'),
+        CustomRoute(
+          page: LoginRoute.page,
+          path: '/login',
+          durationInMilliseconds: 320,
+          reverseDurationInMilliseconds: 280,
+          transitionsBuilder: TransitionsBuilders.slideBottom,
+        ),
       ];
 }

--- a/lib/src/router/app_router.gr.dart
+++ b/lib/src/router/app_router.gr.dart
@@ -27,6 +27,15 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const ReminderScreen(),
       );
     },
+    LoginRoute.name: (routeData) {
+      return CustomPage<dynamic>(
+        routeData: routeData,
+        child: const LoginScreen(),
+        transitionsBuilder: TransitionsBuilders.slideBottom,
+        durationInMilliseconds: 320,
+        reverseDurationInMilliseconds: 280,
+      );
+    },
   };
 }
 
@@ -54,6 +63,20 @@ class ReminderRoute extends PageRouteInfo<void> {
         );
 
   static const String name = 'ReminderRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [LoginScreen]
+class LoginRoute extends PageRouteInfo<void> {
+  const LoginRoute({List<PageRouteInfo>? children})
+      : super(
+          LoginRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'LoginRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
 }


### PR DESCRIPTION
## Summary
- add a dedicated "My" tab that matches the provided profile layout and hooks up the login/register CTA
- introduce the login screen UI and present it with an iOS-style bottom modal transition
- register the new route in the AutoRoute configuration to enable navigation from the home screen

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce888354b88328b04a88278cc88f21